### PR TITLE
Version 0.12

### DIFF
--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
     ca-certificates apt-transport-https
 
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 684A14CF2582E0C5 && \
-    echo "deb https://repos.influxdata.com/debian jessie stable" > /etc/apt/sources.list.d/influxdata.list && \
+    echo "deb https://repos.influxdata.com/debian wheezy stable" > /etc/apt/sources.list.d/influxdata.list && \
     apt-get update
 
 ENV INFLUXDB_VERSION 0.12.2-1

--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -1,0 +1,35 @@
+FROM debian:wheezy
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    ca-certificates apt-transport-https
+
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 684A14CF2582E0C5 && \
+    echo "deb https://repos.influxdata.com/debian jessie stable" > /etc/apt/sources.list.d/influxdata.list && \
+    apt-get update
+
+ENV INFLUXDB_VERSION 0.12.2-1
+ENV TELEGRAF_VERSION 0.12.1-1
+ENV CHRONOGRAF_VERSION 0.12.0
+ENV KAPACITOR_VERSION 0.12.0-1
+RUN apt-get install -y influxdb=$INFLUXDB_VERSION \
+                       telegraf=$TELEGRAF_VERSION \
+                       chronograf=$CHRONOGRAF_VERSION \
+                       kapacitor=$KAPACITOR_VERSION
+
+RUN apt-get install -y supervisor procps
+
+ENV INFLUXDB_CONFIG /etc/influxdb/influxdb.conf
+ENV TELEGRAF_CONFIG /etc/telegraf/telegraf.conf
+ENV CHRONOGRAF_CONFIG /opt/chronograf/config.toml
+ENV KAPACITOR_CONFIG /etc/kapacitor/kapacitor.conf
+
+ENV PATH /opt/chronograf/:$PATH
+ENV CHRONOGRAF_BIND 0.0.0.0:10000
+
+EXPOSE 8083 8086 8088 8091 8125 8092 8094 10000 9092
+
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY listener.py /listener.py
+COPY supervisordRunner.py /supervisordRunner.py
+CMD ["/supervisordRunner.py"]

--- a/0.12/listener.py
+++ b/0.12/listener.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+
+###############################################################
+# Telegraf and Kapacitor must be started only after InfluxDB 
+# starts listening on the HTTP port. 
+#
+# This is a listener, which listens for PROCESS_LOG events
+# based on communication via a subprocess stdin and stdout.
+# @see http://supervisord.org/events.html
+###############################################################
+
+import sys, re
+from supervisor.childutils import listener
+from supervisor.events import notify as notifyEvent
+from subprocess import call
+
+def main():
+    # Telegraf needs to start after the influxdb instance starts listening
+    # otherwise telegraf is not able to connect to the database
+    while True:
+        headers, body = listener.wait(sys.stdin, sys.stdout)
+        # 'Listening for signals' is logged once the db server starts listening
+        # @see cmd/influxd/main.go
+        if re.search(r'Listening for signals', body):
+            call(["supervisorctl", "start", "telegraf"])
+            call(["supervisorctl", "start", "kapacitor"])
+            sys.exit(0)
+        else:
+            listener.ok(sys.stdout)
+
+if __name__ == '__main__':
+    main()

--- a/0.12/supervisord.conf
+++ b/0.12/supervisord.conf
@@ -1,0 +1,38 @@
+[supervisord]
+nodaemon=true
+stderr_logfile=/var/log/supervisor/supervisord.err.log
+
+[program:influxdb]
+command=/bin/bash -c 'exec influxd -config $INFLUXDB_CONFIG'
+redirect_stderr=true
+stdout_events_enabled=true
+stdout_logfile=/var/log/supervisor/influxdb.log
+stderr_logfile=/var/log/supervisor/influxdb.err.log
+
+[program:telegraf]
+command=/bin/bash -c 'exec telegraf -config $TELEGRAF_CONFIG'
+autostart=false
+stdout_logfile=/var/log/supervisor/telegraf.log
+stderr_logfile=/var/log/supervisor/telegraf.err.log
+
+[program:chronograf]
+command=/bin/bash -c 'exec chronograf -config $CHRONOGRAF_CONFIG'
+stdout_logfile=/var/log/supervisor/chronograf.log
+stderr_logfile=/var/log/supervisor/chronograf.err.log
+
+[program:kapacitor]
+command=/bin/bash -c 'exec kapacitord -config $KAPACITOR_CONFIG'
+autostart=false
+stdout_logfile=/var/log/supervisor/kapacitor.log
+stderr_logfile=/var/log/supervisor/kapacitor.err.log
+
+[eventlistener:influxdblistener]
+command=/usr/bin/python listener.py
+autorestart=false
+events=PROCESS_LOG
+exitcodes=0
+stopsignal=KILL
+killasgroup=true
+stopasgroup=true
+stderr_logfile=/var/log/supervisor/listener.log
+stdout_logfile=/var/log/supervisor/listener.err.log

--- a/0.12/supervisordRunner.py
+++ b/0.12/supervisordRunner.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python
+
+####################################################################
+# This is a runner which starts supervisord. Supervisord picks 
+# it's config from /etc/supervisor/conf.d/ 
+#
+# Even after the listener exits, the process group influxdb keeps on
+# generating log events as stdout_events_enabled is set to true. 
+# So once telegraf starts, the subcribers need to be cleared. 
+# Process group influxdblistener is the only subscriber, hence 
+# it is safe to clear the callbacks.
+#
+# @see events.py https://github.com/Supervisor/supervisor 
+####################################################################
+
+from supervisor.supervisord import main
+from supervisor.events import clear as clearCallbacks
+from subprocess import check_output
+import threading, re
+
+def clearEventCallbacks():
+    while True:
+        # wait till telegraf starts
+        output = check_output(["ps", "-ef"])
+        if re.search(r'telegraf', output):
+            # HACK:: Supervisord still keeps on sending events to a listener
+            # even if the listener process has exited.
+            # Clear the callbacks so no more events are handled, and Error 
+            # messgaes are not logged
+            clearCallbacks()
+            return
+
+if __name__ == '__main__':
+    threading.Thread(target=clearEventCallbacks).start()
+    main()


### PR DESCRIPTION
Added new version (0.12/stable) of TICK Stack.

The dockerfile is based on Debian Wheezy as Debian Jessie is based on
systemd and breaks installation

* updated keyserver URL (helps in restrictive build environments where
  hkp port outbound is blocked)
* updated the version ENV's
* added ENV to make chronograf listen on `0.0.0.0`
* added `procps` package (deps for supervisor) to add ps binary to wheezy image.