### PR TITLE
Fix inability to make backups

### DIFF
--- a/1.3/docker-compose.yml
+++ b/1.3/docker-compose.yml
@@ -17,8 +17,11 @@ services:
     image: influxdb:1.3.5
     volumes:
       - ./data/influxdb:/var/lib/influxdb
+    environment:
+      INFLUXDB_BIND_ADDRESS: "0.0.0.0:8088"
     ports:
       - "8086:8086"
+      - "8088:8088"
   # Define a Chronograf service
   chronograf:
     image: chronograf:1.3.8


### PR DESCRIPTION
Publishes port 8086. This port is necessary for backing up influx database.

Fixes #33 